### PR TITLE
Fix when intersection_observer is used in a non-memoized context

### DIFF
--- a/custom_components/reflex_intersection_observer/intersection_observer.py
+++ b/custom_components/reflex_intersection_observer/intersection_observer.py
@@ -97,10 +97,8 @@ const extractEntry = (entry) => ({
         on_non_intersect = self.event_triggers.get("on_non_intersect")
         if on_intersect is None and on_non_intersect is None:
             return None
-        if on_intersect is None:
-            on_intersect = "undefined"
-        if on_non_intersect is None:
-            on_non_intersect = "undefined"
+        on_intersect = rx.Var.create(on_intersect) if on_intersect is not None else "undefined"
+        on_non_intersect = rx.Var.create(on_non_intersect) if on_non_intersect is not None else "undefined"
         return (
             Environment()
             .from_string(INTERSECTION_OBSERVER_JS)

--- a/intersection_observer_demo/.gitignore
+++ b/intersection_observer_demo/.gitignore
@@ -1,3 +1,4 @@
+.states
 *.db
 *.py[cod]
 .web

--- a/intersection_observer_demo/intersection_observer_demo/intersection_observer_demo.py
+++ b/intersection_observer_demo/intersection_observer_demo/intersection_observer_demo.py
@@ -5,7 +5,7 @@ from reflex_intersection_observer import (
     IntersectionObserverEntry,
 )
 
-from . import readme, scroll_to_bottom
+from . import readme, repro_foreach, scroll_to_bottom
 
 
 BATCH_SIZE = 15
@@ -87,4 +87,8 @@ app.add_page(
 app.add_page(
     readme.page,
     route="/readme",
+)
+app.add_page(
+    repro_foreach.page,
+    route="/repro-foreach",
 )

--- a/intersection_observer_demo/intersection_observer_demo/repro_foreach.py
+++ b/intersection_observer_demo/intersection_observer_demo/repro_foreach.py
@@ -1,0 +1,40 @@
+import reflex as rx
+
+from reflex_intersection_observer import intersection_observer
+
+
+BOTTOM_ELEMENT_ID = "bottom"
+
+
+def page():
+    return rx.vstack(
+        rx.heading("Repro Foreach example"),
+        rx.scroll_area(
+            rx.vstack(
+                rx.foreach([f"item {x}" for x in range(10)], rx.text),
+                rx.foreach(
+                    [1],
+                    lambda _: intersection_observer(
+                        "Infinite Scroll Target",
+                        id=BOTTOM_ELEMENT_ID,
+                        root="#scroller",
+                        root_margin="0px",
+                        threshold=0.9,
+                        on_intersect=rx.toast("Intersected"),
+                        on_non_intersect=rx.toast("Non-intersected"),
+                        # The target object doesn't need to be visible.
+                        # visibility="hidden"
+                    ),
+                ),
+                justify="start",
+                spacing="3",
+                font_size="2em",
+            ),
+            type="hover",
+            id="scroller",
+            border=f"1px solid {rx.color('accent', 12)}",
+            width="85vw",
+            height="75vh",
+        ),
+        align="center",
+    )


### PR DESCRIPTION
When intersection observer appears in a cond or foreach, then the on_intersect and on_non_intersect event handlers have to be converted to actual Vars for rendering to JS code.